### PR TITLE
[feat] 생각해보기 질문 API 구현

### DIFF
--- a/BE/.gitignore
+++ b/BE/.gitignore
@@ -8,6 +8,7 @@ build/
 /.gradle/
 application-oauth.yml
 application.yml
+application-API-KEY.yml
 
 ### STS ###
 .apt_generated

--- a/BE/.gitignore
+++ b/BE/.gitignore
@@ -9,6 +9,7 @@ build/
 application-oauth.yml
 application.yml
 application-API-KEY.yml
+application-chatgpt.yml
 
 ### STS ###
 .apt_generated

--- a/BE/src/main/java/com/FTIsland/BE/ChatGptConfig.java
+++ b/BE/src/main/java/com/FTIsland/BE/ChatGptConfig.java
@@ -1,0 +1,23 @@
+package com.FTIsland.BE;
+
+
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ChatGptConfig {
+    public static final String AUTHORIZATION = "Authorization";
+    public static final String BEARER = "Bearer ";
+    public static final String CHAT_MODEL = "gpt-3.5-turbo";
+    public static final Integer MAX_TOKEN = 300;
+    public static final Boolean STREAM = false;
+    public static final String ROLE = "user";
+
+    public static final String USER = "user";
+    public static final String SYSTEM = "system";
+    public static final String ASSISTANT = "assistant";
+    public static final Double TEMPERATURE = 0.6;
+    //public static final Double TOP_P = 1.0;
+    public static final String MEDIA_TYPE = "application/json; charset=UTF-8";
+    //completions : 질답
+    public static final String CHAT_URL = "https://api.openai.com/v1/chat/completions";
+}

--- a/BE/src/main/java/com/FTIsland/BE/ChatGptMessage.java
+++ b/BE/src/main/java/com/FTIsland/BE/ChatGptMessage.java
@@ -1,0 +1,20 @@
+package com.FTIsland.BE;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Data
+@NoArgsConstructor
+public class ChatGptMessage implements Serializable {
+    private String role;
+    private String content;
+
+    @Builder
+    public ChatGptMessage(String role, String content) {
+        this.role = role;
+        this.content = content;
+    }
+}

--- a/BE/src/main/java/com/FTIsland/BE/ErrorCode.java
+++ b/BE/src/main/java/com/FTIsland/BE/ErrorCode.java
@@ -1,0 +1,26 @@
+package com.FTIsland.BE;
+
+public enum ErrorCode {
+    FAIL(999, "실패"),
+    NOT_SUPPORTED_METHOD(998, "NOT_SUPPORTED_METHOD"),
+    NOT_FOUND_USER(100, "NOT_FOUND_USER"),
+    NOT_FOUND_TOKEN(101, "NOT_FOUND_TOKEN"),
+    MALFORMED_ERROR(102, "MALFORMED_ERROR")
+    ;
+
+    private int code;
+    private String message;
+
+    ErrorCode(int code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/BE/src/main/java/com/FTIsland/BE/config/SecurityConfig.java
+++ b/BE/src/main/java/com/FTIsland/BE/config/SecurityConfig.java
@@ -69,7 +69,8 @@ public class SecurityConfig  {
                                 new AntPathRequestMatcher("/saveBookInfo"),
                                 new AntPathRequestMatcher("/book/info"),
                                 new AntPathRequestMatcher("/saveBookContent"),
-                                new AntPathRequestMatcher("/book/content")
+                                new AntPathRequestMatcher("/book/content"),
+                                new AntPathRequestMatcher("/book/quiz")
                         ).permitAll()
                         //.requestMatchers(new AntPathRequestMatcher("/api/v1/**")).hasRole(Role.USER.name())
                         .anyRequest().authenticated())

--- a/BE/src/main/java/com/FTIsland/BE/controller/QuizController.java
+++ b/BE/src/main/java/com/FTIsland/BE/controller/QuizController.java
@@ -30,6 +30,6 @@ public class QuizController {
         String threeQuiz = chatGptResponse.getChoices().get(0).getMessage().getContent();
         System.out.println(threeQuiz);
 
-        return quizService.makeQuiz(userLevel);
+        return quizService.makeQuiz(threeQuiz);
     }
 }

--- a/BE/src/main/java/com/FTIsland/BE/controller/QuizController.java
+++ b/BE/src/main/java/com/FTIsland/BE/controller/QuizController.java
@@ -3,6 +3,7 @@ package com.FTIsland.BE.controller;
 import com.FTIsland.BE.dto.BookContentDTO;
 import com.FTIsland.BE.dto.ChatGptResponse;
 import com.FTIsland.BE.dto.QuizDTO;
+import com.FTIsland.BE.service.BookInfoService;
 import com.FTIsland.BE.service.ChatGptService;
 import com.FTIsland.BE.service.QuizService;
 import com.FTIsland.BE.service.UserService;
@@ -21,12 +22,19 @@ public class QuizController {
     private final UserService userService;
     private final QuizService quizService;
     private final ChatGptService chatGptService;
+    private final BookInfoService bookInfoService;
 
     @PostMapping("/book/quiz")
     public List<QuizDTO> getQuiz(@RequestBody QuizDTO quizDTO){
+        // 사용자 맞춤형 생각해보기 질문 생성을 위해 user entity의 level 정보 조회
         Integer userLevel = userService.findLevelById(quizDTO.getUserId());
+
+        // 책 이름으로 생각해보기 질문을 생성해야하기 때문에 bookId를 통해 동화 제목 조회
+        String bookTitle = bookInfoService.findNameById(quizDTO.getBookId());
+
+        // 퀴즈 생성
         ChatGptResponse chatGptResponse = null;
-        chatGptResponse = chatGptService.askQuestion(userLevel);
+        chatGptResponse = chatGptService.askQuestion(bookTitle, userLevel);
         String threeQuiz = chatGptResponse.getChoices().get(0).getMessage().getContent();
         System.out.println(threeQuiz);
 

--- a/BE/src/main/java/com/FTIsland/BE/controller/QuizController.java
+++ b/BE/src/main/java/com/FTIsland/BE/controller/QuizController.java
@@ -1,0 +1,27 @@
+package com.FTIsland.BE.controller;
+
+import com.FTIsland.BE.dto.BookContentDTO;
+import com.FTIsland.BE.dto.QuizDTO;
+import com.FTIsland.BE.service.QuizService;
+import com.FTIsland.BE.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class QuizController {
+    private final UserService userService;
+    private final QuizService quizService;
+
+    @PostMapping("/book/quiz")
+    public List<QuizDTO> getQuiz(@RequestBody QuizDTO quizDTO){
+        Integer userLevel = userService.findLevelById(quizDTO.getUserId());
+        return quizService.makeQuiz(userLevel);
+    }
+}

--- a/BE/src/main/java/com/FTIsland/BE/controller/QuizController.java
+++ b/BE/src/main/java/com/FTIsland/BE/controller/QuizController.java
@@ -1,7 +1,9 @@
 package com.FTIsland.BE.controller;
 
 import com.FTIsland.BE.dto.BookContentDTO;
+import com.FTIsland.BE.dto.ChatGptResponse;
 import com.FTIsland.BE.dto.QuizDTO;
+import com.FTIsland.BE.service.ChatGptService;
 import com.FTIsland.BE.service.QuizService;
 import com.FTIsland.BE.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -18,10 +20,16 @@ import java.util.List;
 public class QuizController {
     private final UserService userService;
     private final QuizService quizService;
+    private final ChatGptService chatGptService;
 
     @PostMapping("/book/quiz")
     public List<QuizDTO> getQuiz(@RequestBody QuizDTO quizDTO){
         Integer userLevel = userService.findLevelById(quizDTO.getUserId());
+        ChatGptResponse chatGptResponse = null;
+        chatGptResponse = chatGptService.askQuestion(userLevel);
+        String threeQuiz = chatGptResponse.getChoices().get(0).getMessage().getContent();
+        System.out.println(threeQuiz);
+
         return quizService.makeQuiz(userLevel);
     }
 }

--- a/BE/src/main/java/com/FTIsland/BE/controller/QuizController.java
+++ b/BE/src/main/java/com/FTIsland/BE/controller/QuizController.java
@@ -38,6 +38,10 @@ public class QuizController {
         String threeQuiz = chatGptResponse.getChoices().get(0).getMessage().getContent();
         System.out.println(threeQuiz);
 
-        return quizService.makeQuiz(threeQuiz);
+        // 생성된 퀴즈 3개를 파싱하고 해당 퀴즈 리스트를 주언어, 서브언어로 번역 후 반환
+        return quizService.translationQuiz(
+                quizService.makeQuiz(threeQuiz),
+                quizDTO.getMainLan(),
+                quizDTO.getSubLan());
     }
 }

--- a/BE/src/main/java/com/FTIsland/BE/dto/ChatGptRequest.java
+++ b/BE/src/main/java/com/FTIsland/BE/dto/ChatGptRequest.java
@@ -1,0 +1,37 @@
+package com.FTIsland.BE.dto;
+
+import com.FTIsland.BE.ChatGptMessage;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+//chatGPT에 요청할 DTO Format
+public class ChatGptRequest implements Serializable {
+    private String model;
+    @JsonProperty("max_tokens")
+    private Integer maxTokens;
+    private Double temperature;
+    private Boolean stream;
+    private List<ChatGptMessage> messages;
+
+    //@JsonProperty("top_p")
+    //private Double topP;
+
+    @Builder
+    public ChatGptRequest(String model, Integer maxTokens, Double temperature,
+                          Boolean stream, List<ChatGptMessage> messages
+            /*,Double topP*/) {
+        this.model = model;
+        this.maxTokens = maxTokens;
+        this.temperature = temperature;
+        this.stream = stream;
+        this.messages = messages;
+        //this.topP = topP;
+    }
+}

--- a/BE/src/main/java/com/FTIsland/BE/dto/ChatGptResponse.java
+++ b/BE/src/main/java/com/FTIsland/BE/dto/ChatGptResponse.java
@@ -1,0 +1,41 @@
+package com.FTIsland.BE.dto;
+
+import com.FTIsland.BE.ChatGptMessage;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+//ChatGPT 답변을 담을 DTO
+public class ChatGptResponse {
+    private String id;
+    private String object;
+    private long created;
+    private String model;
+    private Usage usage;
+    private List<Choice> choices;
+
+    @Getter
+    @Setter
+    public static class Usage {
+        @JsonProperty("prompt_tokens")
+        private int promptTokens;
+        @JsonProperty("completion_tokens")
+        private int completionTokens;
+        @JsonProperty("total_tokens")
+        private int totalTokens;
+    }
+
+    @Getter
+    @Setter
+    public static class Choice {
+        private ChatGptMessage message;
+        @JsonProperty("finish_reason")
+        private String finishReason;
+        private int index;
+    }
+}

--- a/BE/src/main/java/com/FTIsland/BE/dto/QuestionRequest.java
+++ b/BE/src/main/java/com/FTIsland/BE/dto/QuestionRequest.java
@@ -1,0 +1,13 @@
+package com.FTIsland.BE.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Getter
+@NoArgsConstructor
+//Front단에서 요청하는 DTO
+public class QuestionRequest implements Serializable {
+    private String question;
+}

--- a/BE/src/main/java/com/FTIsland/BE/dto/QuizDTO.java
+++ b/BE/src/main/java/com/FTIsland/BE/dto/QuizDTO.java
@@ -1,0 +1,20 @@
+package com.FTIsland.BE.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@ToString
+public class QuizDTO {
+    private Long userId;
+    private Integer bookId;
+    private String question;
+
+    public QuizDTO(String question){
+        this.question = question;
+    }
+}

--- a/BE/src/main/java/com/FTIsland/BE/dto/QuizDTO.java
+++ b/BE/src/main/java/com/FTIsland/BE/dto/QuizDTO.java
@@ -12,9 +12,15 @@ import lombok.ToString;
 public class QuizDTO {
     private Long userId;
     private Integer bookId;
+    private String mainLan;
+    private String subLan;
     private String question;
+    private String mainQuestion;
+    private String subQuestion;
 
-    public QuizDTO(String question){
+    public QuizDTO(String question, String mainQuestion, String subQuestion){
         this.question = question;
+        this.mainQuestion = mainQuestion;
+        this.subQuestion = subQuestion;
     }
 }

--- a/BE/src/main/java/com/FTIsland/BE/repository/UserRepository.java
+++ b/BE/src/main/java/com/FTIsland/BE/repository/UserRepository.java
@@ -15,6 +15,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByRefreshToken(String refreshToken);
 
+    Optional<User> findById(Long id);
+
     /**
      * 소셜 타입과 소셜의 식별값으로 회원 찾는 메소드
      * 정보 제공을 동의한 순간 DB에 저장해야하지만, 아직 추가 정보(사는 도시, 나이 등)를 입력받지 않았으므로

--- a/BE/src/main/java/com/FTIsland/BE/service/BookInfoService.java
+++ b/BE/src/main/java/com/FTIsland/BE/service/BookInfoService.java
@@ -37,4 +37,15 @@ public class BookInfoService {
             return null;
         }
     }
+
+    public String findNameById(Integer id) {
+        Optional<BookInfoEntity> byId = bookInfoRepository.findById(id);
+        if(byId.isPresent()){
+            BookInfoEntity bookInfoEntity = byId.get();
+            String bookTitle = bookInfoEntity.getTitle();
+            return bookTitle;
+        } else {
+            return null;
+        }
+    }
 }

--- a/BE/src/main/java/com/FTIsland/BE/service/ChatGptService.java
+++ b/BE/src/main/java/com/FTIsland/BE/service/ChatGptService.java
@@ -1,0 +1,93 @@
+package com.FTIsland.BE.service;
+
+
+import com.FTIsland.BE.ChatGptConfig;
+import com.FTIsland.BE.ChatGptMessage;
+import com.FTIsland.BE.dto.ChatGptRequest;
+import com.FTIsland.BE.dto.ChatGptResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class ChatGptService {
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @Value("${api-key.chat-gpt}")
+    private String apiKey;
+
+    public HttpEntity<ChatGptRequest> buildHttpEntity(ChatGptRequest chatGptRequest){
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setContentType(MediaType.parseMediaType(ChatGptConfig.MEDIA_TYPE));
+        httpHeaders.add(ChatGptConfig.AUTHORIZATION, ChatGptConfig.BEARER + apiKey);
+        return new HttpEntity<>(chatGptRequest, httpHeaders);
+    }
+
+    public ChatGptResponse getResponse(HttpEntity<ChatGptRequest> chatGptRequestHttpEntity){
+
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(60000);
+        //답변이 길어질 경우 TimeOut Error가 발생하니 1분정도 설정해줍니다.
+        requestFactory.setReadTimeout(60 * 1000);   //  1min = 60 sec * 1,000ms
+        restTemplate.setRequestFactory(requestFactory);
+
+        ResponseEntity<ChatGptResponse> responseEntity = restTemplate.postForEntity(
+                ChatGptConfig.CHAT_URL,
+                chatGptRequestHttpEntity,
+                ChatGptResponse.class);
+
+        return responseEntity.getBody();
+    }
+    public ChatGptResponse askQuestion(Integer userLevel){
+
+        String finalQuestion = "콩쥐팥쥐 동화를 읽은 5세 아이에게 정답이 없는 생각해볼만한 질문을 3개만 해줘.";
+
+        List<ChatGptMessage> messages = new ArrayList<>();
+        messages.add(ChatGptMessage.builder()
+                .role(ChatGptConfig.USER)
+                .content("아기 돼지 삼형제 동화를 읽은 5세 아이에게 할 수 있는 정답이 없는 생각해볼만한 질문을 3개만 해줘.")
+                .build());
+        messages.add(ChatGptMessage.builder()
+                .role(ChatGptConfig.ASSISTANT)
+                .content("1. 만약에 네가 돼지라면, 너는 어떤 재료로 집을 지을 거야? 왜 그 재료를 선택했을까?\n" +
+                        "2. 세 번째 돼지처럼 너도 집을 지을 때, 어떤 비밀 장치를 집어넣을 거야? 그 이유는 뭐야?\n" +
+                        "3. 만약에 이야기의 끝이 달라져서, 돼지 삼형제가 늑대와 친구가 될 수 있다면, 어떤 모험이 벌어질 것 같아?")
+                .build());
+        messages.add(ChatGptMessage.builder()
+                .role(ChatGptConfig.SYSTEM)
+                .content("assistant는 다정하고 친절한 엄마야")
+                .build());
+        messages.add(ChatGptMessage.builder()
+                .role(ChatGptConfig.ROLE)
+//                .content(questionRequest.getQuestion())
+                .content(finalQuestion)
+                .build());
+        return this.getResponse(
+                this.buildHttpEntity(
+                        new ChatGptRequest(
+                                ChatGptConfig.CHAT_MODEL,
+                                ChatGptConfig.MAX_TOKEN,
+                                ChatGptConfig.TEMPERATURE,
+                                ChatGptConfig.STREAM,
+                                messages
+                                //ChatGptConfig.TOP_P
+                        )
+                )
+        );
+    }
+
+}

--- a/BE/src/main/java/com/FTIsland/BE/service/ChatGptService.java
+++ b/BE/src/main/java/com/FTIsland/BE/service/ChatGptService.java
@@ -54,12 +54,12 @@ public class ChatGptService {
     }
     public ChatGptResponse askQuestion(Integer userLevel){
 
-        String finalQuestion = "콩쥐팥쥐 동화를 읽은 5세 아이에게 정답이 없는 생각해볼만한 질문을 3개만 해줘.";
+        String finalQuestion = "콩쥐팥쥐 동화를 읽은 " + userLevel + "세 아이에게 정답이 없는 생각해볼만한 질문을 3개만 해줘.";
 
         List<ChatGptMessage> messages = new ArrayList<>();
         messages.add(ChatGptMessage.builder()
                 .role(ChatGptConfig.USER)
-                .content("아기 돼지 삼형제 동화를 읽은 5세 아이에게 할 수 있는 정답이 없는 생각해볼만한 질문을 3개만 해줘.")
+                .content("아기 돼지 삼형제 동화를 읽은 " + userLevel + "세 아이에게 할 수 있는 정답이 없는 생각해볼만한 질문을 3개만 해줘.")
                 .build());
         messages.add(ChatGptMessage.builder()
                 .role(ChatGptConfig.ASSISTANT)

--- a/BE/src/main/java/com/FTIsland/BE/service/ChatGptService.java
+++ b/BE/src/main/java/com/FTIsland/BE/service/ChatGptService.java
@@ -52,9 +52,9 @@ public class ChatGptService {
 
         return responseEntity.getBody();
     }
-    public ChatGptResponse askQuestion(Integer userLevel){
+    public ChatGptResponse askQuestion(String bookTitle, Integer userLevel){
 
-        String finalQuestion = "콩쥐팥쥐 동화를 읽은 " + userLevel + "세 아이에게 정답이 없는 생각해볼만한 질문을 3개만 해줘.";
+        String finalQuestion = bookTitle + " 동화를 읽은 " + userLevel + "세 아이에게 정답이 없는 생각해볼만한 질문을 3개만 해줘.";
 
         List<ChatGptMessage> messages = new ArrayList<>();
         messages.add(ChatGptMessage.builder()

--- a/BE/src/main/java/com/FTIsland/BE/service/QuizService.java
+++ b/BE/src/main/java/com/FTIsland/BE/service/QuizService.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 public class QuizService {
     public List<QuizDTO> makeQuiz(Integer userLevel){
         // 퀴즈 생성
+
         // 리스트에 질문 3개 담기
         List<QuizDTO> quizDTOS = new ArrayList<>();
         quizDTOS.add(new QuizDTO("늑대는 어땠을까요?"));

--- a/BE/src/main/java/com/FTIsland/BE/service/QuizService.java
+++ b/BE/src/main/java/com/FTIsland/BE/service/QuizService.java
@@ -1,0 +1,25 @@
+package com.FTIsland.BE.service;
+
+
+import com.FTIsland.BE.dto.QuizDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class QuizService {
+    public List<QuizDTO> makeQuiz(Integer userLevel){
+        // 퀴즈 생성
+        // 리스트에 질문 3개 담기
+        List<QuizDTO> quizDTOS = new ArrayList<>();
+        quizDTOS.add(new QuizDTO("늑대는 어땠을까요?"));
+        quizDTOS.add(new QuizDTO("돼지 엄마는 어땠을까요?"));
+        // QuizDTO List 반환
+        return quizDTOS;
+    }
+
+}

--- a/BE/src/main/java/com/FTIsland/BE/service/QuizService.java
+++ b/BE/src/main/java/com/FTIsland/BE/service/QuizService.java
@@ -12,19 +12,51 @@ import java.util.Optional;
 @Service
 @RequiredArgsConstructor
 public class QuizService {
-    public List<QuizDTO> makeQuiz(String threeQuiz){
+    private final TranslationService translationService;
+
+    public List<QuizDTO> makeQuiz(String threeQuiz) {
         // 리스트에 질문 3개 담기
         // 1. parsing
         String quizLine[] = threeQuiz.split("\n");
 
         // 2. list에 추가
         List<QuizDTO> quizDTOS = new ArrayList<>();
-        quizDTOS.add(new QuizDTO(quizLine[0]));
-        quizDTOS.add(new QuizDTO(quizLine[1]));
-        quizDTOS.add(new QuizDTO(quizLine[2]));
+        quizDTOS.add(new QuizDTO(quizLine[0], null, null));
+        quizDTOS.add(new QuizDTO(quizLine[1], null, null));
+        quizDTOS.add(new QuizDTO(quizLine[2], null, null));
 
         // QuizDTO List 반환
         return quizDTOS;
     }
 
+    public List<QuizDTO> translationQuiz(List<QuizDTO> quizDTOS, String mainLan, String subLan) {
+
+        List<QuizDTO> translatedQuizDTOS = new ArrayList<>();
+
+        String selectedLanguage = "ko";
+
+        for (QuizDTO dto : quizDTOS) {
+            // 번역 로직
+
+            // 1. 주, 보조 언어 텍스트 둘 다 한국어를 기본으로 설정
+            String mainText = dto.getQuestion();
+            String subText = dto.getQuestion();
+
+            // 2. 요청한 언어에 맞게 번역
+            if (mainLan.equals("ko")) { // 주 언어가 한국어가 아니라면 번역해서 저장
+                selectedLanguage = subLan;
+                subText = translationService.test(selectedLanguage, subText);
+            }
+            if (subLan.equals("ko")) { // 보조 언어가 한국어가 아니라면 번역해서 저장
+                selectedLanguage = mainLan;
+                mainText = translationService.test(selectedLanguage, mainText);
+            }
+
+            // DTO List에 추가
+            translatedQuizDTOS.add(new QuizDTO(null, mainText, subText));
+        }
+
+        return translatedQuizDTOS;
+
+    }
 }

--- a/BE/src/main/java/com/FTIsland/BE/service/QuizService.java
+++ b/BE/src/main/java/com/FTIsland/BE/service/QuizService.java
@@ -12,13 +12,17 @@ import java.util.Optional;
 @Service
 @RequiredArgsConstructor
 public class QuizService {
-    public List<QuizDTO> makeQuiz(Integer userLevel){
-        // 퀴즈 생성
-
+    public List<QuizDTO> makeQuiz(String threeQuiz){
         // 리스트에 질문 3개 담기
+        // 1. parsing
+        String quizLine[] = threeQuiz.split("\n");
+
+        // 2. list에 추가
         List<QuizDTO> quizDTOS = new ArrayList<>();
-        quizDTOS.add(new QuizDTO("늑대는 어땠을까요?"));
-        quizDTOS.add(new QuizDTO("돼지 엄마는 어땠을까요?"));
+        quizDTOS.add(new QuizDTO(quizLine[0]));
+        quizDTOS.add(new QuizDTO(quizLine[1]));
+        quizDTOS.add(new QuizDTO(quizLine[2]));
+
         // QuizDTO List 반환
         return quizDTOS;
     }

--- a/BE/src/main/java/com/FTIsland/BE/service/TranslationService.java
+++ b/BE/src/main/java/com/FTIsland/BE/service/TranslationService.java
@@ -5,13 +5,15 @@ import com.google.cloud.translate.Translate;
 import com.google.cloud.translate.TranslateOptions;
 import com.google.cloud.translate.Translation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class TranslationService {
+    @Value("${google.translation.api-key}")
+    private String apiKey;
     public String test(String selectedLanguage, String text) {
-        String apiKey = "api key"; // 보안 문제로 github x
 
         Translate translate = TranslateOptions.newBuilder().setApiKey(apiKey).build().getService(); // Translate 클라이언트를 빌드
 

--- a/BE/src/main/java/com/FTIsland/BE/service/UserService.java
+++ b/BE/src/main/java/com/FTIsland/BE/service/UserService.java
@@ -1,5 +1,7 @@
 package com.FTIsland.BE.service;
 
+import com.FTIsland.BE.dto.BookInfoDTO;
+import com.FTIsland.BE.dto.QuizDTO;
 import com.FTIsland.BE.dto.UserSignUpDTO;
 import com.FTIsland.BE.entity.Role;
 import com.FTIsland.BE.entity.User;
@@ -8,6 +10,8 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 
 @Service
 @Transactional
@@ -39,6 +43,16 @@ public class UserService { // 자체 로그인 회원 가입 시 사용하는 �
 
         user.passwordEncode(passwordEncoder);
         userRepository.save(user);
+    }
+
+    public Integer findLevelById(Long userId){
+        Optional<User> byId = userRepository.findById(userId);
+        if(byId.isPresent()){
+            User userInfo = byId.get();
+            return userInfo.getLevel();
+        } else { // 해당 유저가 존재하지 않을 때
+            return null;
+        }
     }
 
 }

--- a/BE/src/main/resources/application.yml
+++ b/BE/src/main/resources/application.yml
@@ -23,6 +23,7 @@ spring:
     include:
       - oauth
       - API-KEY
+      - chatgpt
     group:
       "local": "local, jwt, oauth"
     active: local

--- a/BE/src/main/resources/application.yml
+++ b/BE/src/main/resources/application.yml
@@ -20,7 +20,9 @@ spring:
 
   # oauth 설정
   profiles:
-    include: oauth
+    include:
+      - oauth
+      - API-KEY
     group:
       "local": "local, jwt, oauth"
     active: local


### PR DESCRIPTION
### Summary

- chatgpt API를 이용하여 사용자 맞춤형 퀴즈 생성
- 저장 없이 그때그때 생성
- 주언어, 서브언어로 번역된 퀴즈 3개가 list로 반환
- 회원 + 비회원 같은 로직

### Branch : feat/#19

### etc

- 2/17 회의 때 동화-레벨-언어 조합으로 DB에 저장할지 지금처럼 실시간 생성으로 할지 결정
- 2/17 회의 때 비회원 전용 계정을 둬서 회원, 비회원 같은 로직으로 할지 / 다른 방식으로 해서 다른 로직으로 할지 결정
