### PR TITLE
[feat] 주 언어, 보조 언어 입력 API 구현

### DIFF
--- a/BE/src/main/java/com/FTIsland/BE/config/SecurityConfig.java
+++ b/BE/src/main/java/com/FTIsland/BE/config/SecurityConfig.java
@@ -70,7 +70,8 @@ public class SecurityConfig  {
                                 new AntPathRequestMatcher("/book/info"),
                                 new AntPathRequestMatcher("/saveBookContent"),
                                 new AntPathRequestMatcher("/book/content"),
-                                new AntPathRequestMatcher("/book/quiz")
+                                new AntPathRequestMatcher("/book/quiz"),
+                                new AntPathRequestMatcher("/language")
                         ).permitAll()
                         //.requestMatchers(new AntPathRequestMatcher("/api/v1/**")).hasRole(Role.USER.name())
                         .anyRequest().authenticated())

--- a/BE/src/main/java/com/FTIsland/BE/controller/LanguageController.java
+++ b/BE/src/main/java/com/FTIsland/BE/controller/LanguageController.java
@@ -1,0 +1,23 @@
+package com.FTIsland.BE.controller;
+
+import com.FTIsland.BE.dto.UserLanguageDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import com.FTIsland.BE.service.UserService;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class LanguageController {
+
+    private final UserService userService;
+
+    @PostMapping("/language")
+    public UserLanguageDTO saveUserLanguage(@RequestBody UserLanguageDTO userLanguageDTO){ // DB에 동화 정보 저장
+        return userService.save(userLanguageDTO);
+    }
+}

--- a/BE/src/main/java/com/FTIsland/BE/dto/UserLanguageDTO.java
+++ b/BE/src/main/java/com/FTIsland/BE/dto/UserLanguageDTO.java
@@ -1,0 +1,23 @@
+package com.FTIsland.BE.dto;
+
+import com.FTIsland.BE.entity.User;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@ToString
+public class UserLanguageDTO {
+    private Long userId;
+    private String mainLanguage;
+    private String subLanguage;
+
+    public UserLanguageDTO(Long userId, String mainLanguage, String subLanguage) {
+        this.userId = userId;
+        this.mainLanguage = mainLanguage;
+        this.subLanguage = subLanguage;
+    }
+}

--- a/BE/src/main/java/com/FTIsland/BE/entity/User.java
+++ b/BE/src/main/java/com/FTIsland/BE/entity/User.java
@@ -7,6 +7,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Builder

--- a/BE/src/main/java/com/FTIsland/BE/repository/UserRepository.java
+++ b/BE/src/main/java/com/FTIsland/BE/repository/UserRepository.java
@@ -1,4 +1,5 @@
 package com.FTIsland.BE.repository;
+import com.FTIsland.BE.dto.UserLanguageDTO;
 import com.FTIsland.BE.entity.SocialType;
 import com.FTIsland.BE.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -24,4 +25,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
      * 따라서 추가 정보를 입력받아 회원 가입을 진행할 때 소셜 타입, 식별자로 해당 회원을 찾기 위한 메소드
      */
     Optional<User> findBySocialTypeAndSocialId(SocialType socialType, String socialId);
+
 }

--- a/BE/src/main/java/com/FTIsland/BE/service/UserService.java
+++ b/BE/src/main/java/com/FTIsland/BE/service/UserService.java
@@ -2,6 +2,7 @@ package com.FTIsland.BE.service;
 
 import com.FTIsland.BE.dto.BookInfoDTO;
 import com.FTIsland.BE.dto.QuizDTO;
+import com.FTIsland.BE.dto.UserLanguageDTO;
 import com.FTIsland.BE.dto.UserSignUpDTO;
 import com.FTIsland.BE.entity.Role;
 import com.FTIsland.BE.entity.User;
@@ -30,7 +31,7 @@ public class UserService { // 자체 로그인 회원 가입 시 사용하는 �
             throw new Exception("이미 존재하는 이름입니다.");
         }
 
-        User user = User.builder()
+        User user = User.builder() // 자체 로그인에서는 mainLanguage, subLanguage를 입력하니까 바로 USER로 등록함
                 .email(userSignUpDto.getEmail())
                 .password(userSignUpDto.getPassword())
                 .name(userSignUpDto.getName())
@@ -55,4 +56,12 @@ public class UserService { // 자체 로그인 회원 가입 시 사용하는 �
         }
     }
 
+    public UserLanguageDTO save(UserLanguageDTO userLanguageDTO) {
+        // 넘어온 userId, mainLanguage, subLanguage로 userDB에 저장하기
+        User user = userRepository.findById(userLanguageDTO.getUserId()).get();
+        user.setMainLanguage(userLanguageDTO.getMainLanguage());
+        user.setSubLanguage(userLanguageDTO.getSubLanguage());
+        userRepository.save(user);
+        return userLanguageDTO;
+    }
 }


### PR DESCRIPTION
### Summary

- userLanguage의 request, response를 모두 처리하기 위한 UserLanguageDTO 설정
- /language를 다루는 LanguageController 
- main/sub language를 입력한 경우 사용자의 ROLE을 GUEST에서 USER로 변경
- 회원만 사용하는 API, 비회원인 경우 DB에 저장할 필요 없으므로 API 사용하지 않음

### Branch : feat/#22

### etc

- main, sub 둘 중 하나라도 null인 경우에 대한 처리를 백엔드에서 한다면 추후 처리 필요
- userId가 음수이면 비회원이고, 백엔드에서 main, sub를 기억하지 않음
