### PR TITLE
[fix] 구글 로그인 후 accessToken, userId 반환하도록 수정

### DIFF
--- a/BE/src/main/java/com/FTIsland/BE/controller/UserController.java
+++ b/BE/src/main/java/com/FTIsland/BE/controller/UserController.java
@@ -1,15 +1,21 @@
 package com.FTIsland.BE.controller;
 
 import com.FTIsland.BE.dto.UserSignUpDTO;
+import com.FTIsland.BE.entity.User;
 import com.FTIsland.BE.service.UserService;
+import com.nimbusds.oauth2.sdk.auth.JWTAuthentication;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.nio.file.attribute.UserPrincipal;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
+@Slf4j
 public class UserController {
 
     private final UserService userService;
@@ -24,4 +30,11 @@ public class UserController {
     public String jwtTest() {
         return "jwtTest 요청 성공";
     }
+
+//    @PostMapping("/oauth/info")
+//    public void getUserId(@AuthenticationPrincipal JwtAuthenticationToken userPrincipal) {
+//        log.info(userPrincipal.getName());
+//       // log.info(String.valueOf(userService.getUserId(userPrincipal.getEmail())));
+//        //return userService.getUserId(userPrincipal.getEmail());
+//    }
 }

--- a/BE/src/main/java/com/FTIsland/BE/jwt/filter/JwtAuthenticationProcessingFilter.java
+++ b/BE/src/main/java/com/FTIsland/BE/jwt/filter/JwtAuthenticationProcessingFilter.java
@@ -86,7 +86,7 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
         userRepository.findByRefreshToken(refreshToken)
                 .ifPresent(user -> {
                     String reIssuedRefreshToken = reIssueRefreshToken(user);
-                    jwtService.sendAccessAndRefreshToken(response, jwtService.createAccessToken(user.getEmail()),
+                    jwtService.sendAccessAndRefreshToken(response, jwtService.createAccessToken(user.getId(), user.getEmail()),
                             reIssuedRefreshToken);
                 });
     }

--- a/BE/src/main/java/com/FTIsland/BE/jwt/service/JwtService.java
+++ b/BE/src/main/java/com/FTIsland/BE/jwt/service/JwtService.java
@@ -43,6 +43,7 @@ public class JwtService {
     private static final String ACCESS_TOKEN_SUBJECT = "AccessToken";
     private static final String REFRESH_TOKEN_SUBJECT = "RefreshToken";
     private static final String EMAIL_CLAIM = "email";
+    private static final String ID_CLAIM = "id";
     private static final String BEARER = "Bearer ";
 
     private final UserRepository userRepository;
@@ -50,7 +51,7 @@ public class JwtService {
     /**
      * AccessToken 생성 메소드
      */
-    public String createAccessToken(String email) {
+    public String createAccessToken(Long id, String email) {
         log.info("JwtService - createAccessToken");
         Date now = new Date();
 
@@ -62,6 +63,7 @@ public class JwtService {
                 //추가적으로 식별자나, 이름 등의 정보를 더 추가하셔도 됩니다.
                 //추가하실 경우 .withClaim(클래임 이름, 클래임 값) 으로 설정해주시면 됩니다
                 .withClaim(EMAIL_CLAIM, email)
+                .withClaim(ID_CLAIM, id)
                 .sign(Algorithm.HMAC512(secretKey)));
         return JWT.create() // JWT 토큰을 생성하는 빌더 반환
                 .withSubject(ACCESS_TOKEN_SUBJECT) // JWT의 Subject 지정 -> AccessToken이므로 AccessToken
@@ -71,6 +73,7 @@ public class JwtService {
                 //추가적으로 식별자나, 이름 등의 정보를 더 추가하셔도 됩니다.
                 //추가하실 경우 .withClaim(클래임 이름, 클래임 값) 으로 설정해주시면 됩니다
                 .withClaim(EMAIL_CLAIM, email)
+                .withClaim(ID_CLAIM, id)
                 .sign(Algorithm.HMAC512(secretKey)); // HMAC512 알고리즘 사용, application-jwt.yml에서 지정한 secret 키로 암호화
     }
 

--- a/BE/src/main/java/com/FTIsland/BE/login/handler/LoginSuccessHandler.java
+++ b/BE/src/main/java/com/FTIsland/BE/login/handler/LoginSuccessHandler.java
@@ -24,8 +24,10 @@ public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
                                         Authentication authentication) {
-        String email = extractUsername(authentication); // 인증 정보에서 Username(email) 추출
-        String accessToken = jwtService.createAccessToken(email); // JwtService의 createAccessToken을 사용하여 AccessToken 발급
+        String email = extractUsername(authentication); // 인증 정보에서 email 추출
+        Long id = extractUserId(authentication); // 인증 정보에서 id 추출
+
+        String accessToken = jwtService.createAccessToken(id, email); // JwtService의 createAccessToken을 사용하여 AccessToken 발급
         String refreshToken = jwtService.createRefreshToken(); // JwtService의 createRefreshToken을 사용하여 RefreshToken 발급
 
         jwtService.sendAccessAndRefreshToken(response, accessToken, refreshToken); // 응답 헤더에 AccessToken, RefreshToken 실어서 응답
@@ -35,6 +37,7 @@ public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
                     user.updateRefreshToken(refreshToken);
                     userRepository.saveAndFlush(user);
                 });
+        log.info("로그인에 성공하였습니다. id : {}", id);
         log.info("로그인에 성공하였습니다. 이메일 : {}", email);
         log.info("로그인에 성공하였습니다. AccessToken : {}", accessToken);
         log.info("발급된 AccessToken 만료 기간 : {}", accessTokenExpiration);
@@ -43,5 +46,12 @@ public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
     private String extractUsername(Authentication authentication) {
         UserDetails userDetails = (UserDetails) authentication.getPrincipal();
         return userDetails.getUsername();
+    }
+
+    // extractUserId 임시 생성
+    private Long extractUserId(Authentication authentication) {
+        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+        Long id = 123456L; // 임시로 id 생성, 원래는 email로 등록한 후 return된 id를 받아야 함
+        return id;
     }
 }

--- a/BE/src/main/java/com/FTIsland/BE/oauth2/CustomOAuth2User.java
+++ b/BE/src/main/java/com/FTIsland/BE/oauth2/CustomOAuth2User.java
@@ -14,6 +14,7 @@ import java.util.Map;
 @Getter
 public class CustomOAuth2User extends DefaultOAuth2User {
 
+    private Long id;
     private String email;
     private Role role;
 
@@ -27,8 +28,9 @@ public class CustomOAuth2User extends DefaultOAuth2User {
      */
     public CustomOAuth2User(Collection<? extends GrantedAuthority> authorities,
                             Map<String, Object> attributes, String nameAttributeKey,
-                            String email, Role role) {
+                            Long id, String email, Role role) {
         super(authorities, attributes, nameAttributeKey);
+        this.id = id;
         this.email = email;
         this.role = role;
     }

--- a/BE/src/main/java/com/FTIsland/BE/oauth2/service/CustomOAuth2UserService.java
+++ b/BE/src/main/java/com/FTIsland/BE/oauth2/service/CustomOAuth2UserService.java
@@ -66,6 +66,7 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
                 Collections.singleton(new SimpleGrantedAuthority(createdUsers.get(0).getRole().getKey())),
                 attributes,
                 extractAttributes.getNameAttributeKey(),
+                createdUsers.get(0).getId(),
                 createdUsers.get(0).getEmail(),
                 createdUsers.get(0).getRole()
         );

--- a/BE/src/main/java/com/FTIsland/BE/service/UserService.java
+++ b/BE/src/main/java/com/FTIsland/BE/service/UserService.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -20,6 +21,14 @@ import java.util.Optional;
 public class UserService { // 자체 로그인 회원 가입 시 사용하는 회원 가입 API의 로직
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+
+    // client에서 받은 access token을 이용해 id의 list를 반환한다.
+    public Long getUserId(String email) {
+        List<Integer> userIds;
+        Optional<User> user = userRepository.findByEmail(email);
+
+        return user.get().getId();
+    }
 
     public void signUp(UserSignUpDTO userSignUpDto) throws Exception {
 


### PR DESCRIPTION
### Summary

- jwt auth filter에서 id를 이용해 token을 생성하도록 수정
- client로 accesstoken과 함께 userId 반환
- 구글 로그인 후 redirect uri : /outh/sign-up?code=~&id=~

### Branch : fix/#26
