### PR TITLE
[fix] 회원가입 유효성 검사 완화 및 비밀번호 확인

### DIFF
--- a/BE/src/main/java/com/FTIsland/BE/dto/SignUpDTO.java
+++ b/BE/src/main/java/com/FTIsland/BE/dto/SignUpDTO.java
@@ -19,7 +19,7 @@ public class SignUpDTO {
     private String inputId;
 
     @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
-    @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,16}", message = "비밀번호는 영문 대/소문자, 숫자, 특수 문자로 이루어진 8~16자여야 합니다.")
+    @Pattern(regexp = "^.{8,16}$", message = "비밀번호는 8자 이상 16자 이하이어야 합니다.")
     private String inputPassword;
 
     @NotBlank(message = "이름은 필수 입력 값입니다.")

--- a/BE/src/main/java/com/FTIsland/BE/service/LoginService.java
+++ b/BE/src/main/java/com/FTIsland/BE/service/LoginService.java
@@ -57,17 +57,28 @@ public class LoginService {
         List<Optional<User>> users = userRepository.findByInputId(loginDTO.getInputId());
         log.info(loginDTO.getInputId());
         log.info(String.valueOf(users.size()));
+        log.info(String.valueOf(users.get(0).get().getInputPassword()));
+        log.info(loginDTO.getInputPassword());
 
         // inputId가 있으면 정보 가져와서 db의 userId, mainlanguage, sublanguage return
         if(users.size() != 0) {
-            UserInfoDTO userInfoDTO = new UserInfoDTO();
-            userInfoDTO.setUserId(users.get(0).get().getId());
-            userInfoDTO.setName(users.get(0).get().getName());
-            userInfoDTO.setMainLanguage(users.get(0).get().getMainLanguage());
-            userInfoDTO.setSubLanguage(users.get(0).get().getSubLanguage());
-            return new ResponseDTO<>(HttpServletResponse.SC_OK, "ok", userInfoDTO);
+            // 정상적으로 비밀번호를 입력해 가입하는 경우
+            if(users.get(0).get().getInputPassword().equals(loginDTO.getInputPassword())) {
+                UserInfoDTO userInfoDTO = new UserInfoDTO();
+                userInfoDTO.setUserId(users.get(0).get().getId());
+                userInfoDTO.setName(users.get(0).get().getName());
+                userInfoDTO.setMainLanguage(users.get(0).get().getMainLanguage());
+                userInfoDTO.setSubLanguage(users.get(0).get().getSubLanguage());
+                return new ResponseDTO<>(HttpServletResponse.SC_OK, "ok", userInfoDTO);
+            }
+            // 비밀번호가 틀린 경우
+            else {
+                return new ResponseDTO<>(HttpServletResponse.SC_OK, "invalid password", null);
+            }
+
 
         } else { // 없으면 ERROR response dto return
+            // input id를 입력하지 않아도 not in database
             return new ResponseDTO<>(HttpServletResponse.SC_NOT_FOUND, "not in database", null);
 
         }

--- a/BE/src/main/java/com/FTIsland/BE/service/LoginService.java
+++ b/BE/src/main/java/com/FTIsland/BE/service/LoginService.java
@@ -55,10 +55,10 @@ public class LoginService {
     public ResponseDTO login(LoginDTO loginDTO) {
         // 사용자가 입력한 id로 User 검색
         List<Optional<User>> users = userRepository.findByInputId(loginDTO.getInputId());
-        log.info(loginDTO.getInputId());
-        log.info(String.valueOf(users.size()));
-        log.info(String.valueOf(users.get(0).get().getInputPassword()));
-        log.info(loginDTO.getInputPassword());
+        //log.info(loginDTO.getInputId());
+        //log.info(String.valueOf(users.size()));
+        //log.info(String.valueOf(users.get(0).get().getInputPassword()));
+        //log.info(loginDTO.getInputPassword());
 
         // inputId가 있으면 정보 가져와서 db의 userId, mainlanguage, sublanguage return
         if(users.size() != 0) {
@@ -77,7 +77,10 @@ public class LoginService {
             }
 
 
-        } else { // 없으면 ERROR response dto return
+        }
+
+        // input id가 없거나 입력하지 않으면
+        else { // 없으면 ERROR response dto return
             // input id를 입력하지 않아도 not in database
             return new ResponseDTO<>(HttpServletResponse.SC_NOT_FOUND, "not in database", null);
 


### PR DESCRIPTION
### Summary

- 회원 가입 시 비밀번호 유효성 검사 기준 완화 (8자 이상 16자 이하로만 조건 변경)
- 로그인 시 inputId가 존재할 경우 케이스 처리 
  1) 아이디 존재, 비밀번호 일치 - user info 포함한 response dto
  2) 아이디 존재, 비밀번호 불일치 - invalid password message와 null을 포함한 response dto
- 로그인 시 inputId가 존재하지 않을 경우 케이스 처리
  1) not in database message와 null을 포함한 response dto


### Branch : fix/#66
