### PR TITLE
[fix] island info 책 정보/진행률 반환 속도 개선

### DIFF
--- a/BE/src/main/java/com/FTIsland/BE/controller/IslandInfoController.java
+++ b/BE/src/main/java/com/FTIsland/BE/controller/IslandInfoController.java
@@ -39,100 +39,101 @@ public class IslandInfoController {
         // 만약 userId가 -1이라면 비회원이므로 book info db를 island id로 검색한 결과만 리턴
         // 비회원인 경우 반환 정상
         List<IslandBooksDTO> islandBooksDTOList = new ArrayList<>();
-        if(islandBooksDTO.getUserId() < 0) {
-            List<Optional<BookInfoEntity>> bookInfoEntityList = bookInfoService.findNameByIslandId(islandBooksDTO.getIslandId());
+        List<Optional<BookInfoEntity>> bookInfoEntityList = bookInfoService.findNameByIslandId(islandBooksDTO.getIslandId());
 
-            // IslandBooksDTO로 변환해서 list로 리턴
+        // IslandBooksDTO로 변환해서 list로 리턴
 
-            for (Optional<BookInfoEntity> bookInfoEntityOptional : bookInfoEntityList) {
-                bookInfoEntityOptional.ifPresent(bookInfoEntity -> {
-                    IslandBooksDTO dto = new IslandBooksDTO(
-                            -1, // 비회원일 경우 userId는 -1로 설정
-                            bookInfoEntity.getId(),
-                            islandBooksDTO.getIslandId(),
-                            bookInfoEntity.getTitle(),
-                            bookInfoEntity.getDescription(),
-                            bookInfoEntity.getCategory(),
-                            bookInfoEntity.getCountry(),
-                            bookInfoEntity.getTotalPage(),
-                            bookInfoEntity.getImage(),
-                            0.00f
-                    );
-                    islandBooksDTOList.add(dto);
-                });
-            }
-            return islandBooksDTOList;
+        for (Optional<BookInfoEntity> bookInfoEntityOptional : bookInfoEntityList) {
+            bookInfoEntityOptional.ifPresent(bookInfoEntity -> {
+                IslandBooksDTO dto = new IslandBooksDTO(
+                        -1, // 비회원일 경우 userId는 -1로 설정
+                        bookInfoEntity.getId(),
+                        islandBooksDTO.getIslandId(),
+                        bookInfoEntity.getTitle(),
+                        bookInfoEntity.getDescription(),
+                        bookInfoEntity.getCategory(),
+                        bookInfoEntity.getCountry(),
+                        bookInfoEntity.getTotalPage(),
+                        bookInfoEntity.getImage(),
+                        0.00f
+                );
+                islandBooksDTOList.add(dto);
+            });
         }
+        return islandBooksDTOList;
+//        if(islandBooksDTO.getUserId() < 0) {
+//
+//        }
         
         // 회원인 경우 read table에서 검색해야 함
         // 회원인 경우 동화책 전체 반환하도록 하기!
-        else {
-            List<Optional<BookInfoEntity>> bookInfoEntityList = bookInfoService.findNameByIslandId(islandBooksDTO.getIslandId());
-            log.info(String.valueOf(bookInfoEntityList.size()));
-
-            List<Optional<ReadEntity>> readEntityList = new ArrayList<>();
-            // IslandBooksDTO로 변환해서 list로 리턴
-
-            for (Optional<BookInfoEntity> bookInfoEntityOptional : bookInfoEntityList) {
-
-                // (bookId, userId)로 read table 검색
-                // 이때 book Id는 이미 island에 해당하는 bookId만을 고른 것임
-                if(bookInfoEntityOptional.isPresent()) {
-                    Integer userId = islandBooksDTO.getUserId();
-                    Integer bookId = bookInfoEntityOptional.get().getId();
-
-                    if (bookId != null) {
-
-                        // read table에서 (userId, bookId) 검색
-                        Optional<ReadEntity> readEntity = readService.findByUserIdAndBookId(userId, bookId);
-
-                        //readEntityList.add(readService.findByUserIdAndBookId(userId, bookId));
-                        if(readEntity.isPresent()) { // optional은 is present 설정 필수
-                            IslandBooksDTO dto = new IslandBooksDTO(
-                                    islandBooksDTO.getUserId(), // 비회원일 경우 userId는 -1로 설정
-                                    readEntity.get().getBookId(), // book id
-                                    islandBooksDTO.getIslandId(), // island id
-                                    bookInfoEntityOptional.get().getTitle(),
-                                    bookInfoEntityOptional.get().getDescription(),
-                                    bookInfoEntityOptional.get().getCategory(),
-                                    bookInfoEntityOptional.get().getCountry(),
-                                    bookInfoEntityOptional.get().getTotalPage(),
-                                    bookInfoEntityOptional.get().getImage(),
-                                    0.00f
-                            );
-
-                            // progress 계산
-                            DecimalFormat df = new DecimalFormat("#.##");
-                            df.setRoundingMode(RoundingMode.HALF_UP);
-
-                            float progressCal = (readEntity.get().getOffset() + 1) * readEntity.get().getLimitNum();
-                            float progressResult = progressCal / bookInfoEntityOptional.get().getTotalPage();
-                            String formattedProgress = df.format(progressResult);
-
-                            float progressTemp = Float.parseFloat(formattedProgress);
-                            dto.setProgress(progressTemp);
-                            islandBooksDTOList.add(dto);
-                        }
-                        else { // read에 없으면 그냥 저장함
-                            IslandBooksDTO dto = new IslandBooksDTO(
-                                    islandBooksDTO.getUserId(), // 비회원일 경우 userId는 -1로 설정
-                                    bookInfoEntityOptional.get().getId(), // book id
-                                    islandBooksDTO.getIslandId(), // island id
-                                    bookInfoEntityOptional.get().getTitle(),
-                                    bookInfoEntityOptional.get().getDescription(),
-                                    bookInfoEntityOptional.get().getCategory(),
-                                    bookInfoEntityOptional.get().getCountry(),
-                                    bookInfoEntityOptional.get().getTotalPage(),
-                                    bookInfoEntityOptional.get().getImage(),
-                                    0.00f
-                            );
-                            islandBooksDTOList.add(dto);
-                        }
-
-                    }
-                }
-            }
-            return islandBooksDTOList;
+//        else {
+//            List<Optional<BookInfoEntity>> bookInfoEntityList = bookInfoService.findNameByIslandId(islandBooksDTO.getIslandId());
+//            log.info(String.valueOf(bookInfoEntityList.size()));
+//
+//            List<Optional<ReadEntity>> readEntityList = new ArrayList<>();
+//            // IslandBooksDTO로 변환해서 list로 리턴
+//
+//            for (Optional<BookInfoEntity> bookInfoEntityOptional : bookInfoEntityList) {
+//
+//                // (bookId, userId)로 read table 검색
+//                // 이때 book Id는 이미 island에 해당하는 bookId만을 고른 것임
+//                if(bookInfoEntityOptional.isPresent()) {
+//                    Integer userId = islandBooksDTO.getUserId();
+//                    Integer bookId = bookInfoEntityOptional.get().getId();
+//
+//                    if (bookId != null) {
+//
+//                        // read table에서 (userId, bookId) 검색
+//                        Optional<ReadEntity> readEntity = readService.findByUserIdAndBookId(userId, bookId);
+//
+//                        //readEntityList.add(readService.findByUserIdAndBookId(userId, bookId));
+//                        if(readEntity.isPresent()) { // optional은 is present 설정 필수
+//                            IslandBooksDTO dto = new IslandBooksDTO(
+//                                    islandBooksDTO.getUserId(), // 비회원일 경우 userId는 -1로 설정
+//                                    readEntity.get().getBookId(), // book id
+//                                    islandBooksDTO.getIslandId(), // island id
+//                                    bookInfoEntityOptional.get().getTitle(),
+//                                    bookInfoEntityOptional.get().getDescription(),
+//                                    bookInfoEntityOptional.get().getCategory(),
+//                                    bookInfoEntityOptional.get().getCountry(),
+//                                    bookInfoEntityOptional.get().getTotalPage(),
+//                                    bookInfoEntityOptional.get().getImage(),
+//                                    0.00f
+//                            );
+//
+//                            // progress 계산
+//                            DecimalFormat df = new DecimalFormat("#.##");
+//                            df.setRoundingMode(RoundingMode.HALF_UP);
+//
+//                            float progressCal = (readEntity.get().getOffset() + 1) * readEntity.get().getLimitNum();
+//                            float progressResult = progressCal / bookInfoEntityOptional.get().getTotalPage();
+//                            String formattedProgress = df.format(progressResult);
+//
+//                            float progressTemp = Float.parseFloat(formattedProgress);
+//                            dto.setProgress(progressTemp);
+//                            islandBooksDTOList.add(dto);
+//                        }
+//                        else { // read에 없으면 그냥 저장함
+//                            IslandBooksDTO dto = new IslandBooksDTO(
+//                                    islandBooksDTO.getUserId(), // 비회원일 경우 userId는 -1로 설정
+//                                    bookInfoEntityOptional.get().getId(), // book id
+//                                    islandBooksDTO.getIslandId(), // island id
+//                                    bookInfoEntityOptional.get().getTitle(),
+//                                    bookInfoEntityOptional.get().getDescription(),
+//                                    bookInfoEntityOptional.get().getCategory(),
+//                                    bookInfoEntityOptional.get().getCountry(),
+//                                    bookInfoEntityOptional.get().getTotalPage(),
+//                                    bookInfoEntityOptional.get().getImage(),
+//                                    0.00f
+//                            );
+//                            islandBooksDTOList.add(dto);
+//                        }
+//
+//                    }
+//                }
+//            }
+//            return islandBooksDTOList;
 //            log.info("readentitylist" + String.valueOf(readEntityList.size()));
 //
 //            // readEntityList에 있는 정보들을 islandBooksDTOList로 바꿔서 변환
@@ -178,6 +179,6 @@ public class IslandInfoController {
 //            }
 //            log.info(String.valueOf(islandBooksDTOList.size()));
 //            return islandBooksDTOList;
-        }
+
     }
 }

--- a/BE/src/main/java/com/FTIsland/BE/controller/IslandInfoController.java
+++ b/BE/src/main/java/com/FTIsland/BE/controller/IslandInfoController.java
@@ -37,20 +37,8 @@ public class IslandInfoController {
 
     @PostMapping("/book/progress")
     public List<ReadDTO> getBookInfoWithRead(@RequestBody IslandBooksDTO islandBooksDTO) {
-        List<ReadDTO> readDTOS = new ArrayList<>();
-        // islandid에서 힌트를 얻어서 바로 검색
-        int startNum = (islandBooksDTO.getIslandId() - 1) * 4 + 1;
-        for(int i = 0; i < 4; i++) {
-            int nowId = startNum + i;
-            Optional<ReadEntity> readEntityOptional = readService.findByUserIdAndBookId(islandBooksDTO.getUserId(), nowId);
-            if(readEntityOptional.isPresent()) {
-                ReadDTO readDTO = new ReadDTO(islandBooksDTO.getUserId(), readEntityOptional.get().getBookId(),
-                        readEntityOptional.get().getOffset(), readEntityOptional.get().getLimitNum(),
-                        readEntityOptional.get().getOffset() * readEntityOptional.get().getLimitNum());
-                readDTOS.add(readDTO);
-            }
-        }
-        return readDTOS;
+        return readService.progress(islandBooksDTO);
+
     }
 
     @PostMapping("/island/books")

--- a/BE/src/main/java/com/FTIsland/BE/controller/IslandInfoController.java
+++ b/BE/src/main/java/com/FTIsland/BE/controller/IslandInfoController.java
@@ -3,6 +3,7 @@ package com.FTIsland.BE.controller;
 import com.FTIsland.BE.dto.BookInfoDTO;
 import com.FTIsland.BE.dto.IslandBooksDTO;
 import com.FTIsland.BE.dto.IslandInfoDTO;
+import com.FTIsland.BE.dto.ReadDTO;
 import com.FTIsland.BE.entity.BookInfoEntity;
 import com.FTIsland.BE.entity.ReadEntity;
 import com.FTIsland.BE.service.BookInfoService;
@@ -34,6 +35,24 @@ public class IslandInfoController {
         return islandInfoService.findById(islandId);
     }
 
+    @PostMapping("/book/progress")
+    public List<ReadDTO> getBookInfoWithRead(@RequestBody IslandBooksDTO islandBooksDTO) {
+        List<ReadDTO> readDTOS = new ArrayList<>();
+        // islandid에서 힌트를 얻어서 바로 검색
+        int startNum = (islandBooksDTO.getIslandId() - 1) * 4 + 1;
+        for(int i = 0; i < 4; i++) {
+            int nowId = startNum + i;
+            Optional<ReadEntity> readEntityOptional = readService.findByUserIdAndBookId(islandBooksDTO.getUserId(), nowId);
+            if(readEntityOptional.isPresent()) {
+                ReadDTO readDTO = new ReadDTO(islandBooksDTO.getUserId(), readEntityOptional.get().getBookId(),
+                        readEntityOptional.get().getOffset(), readEntityOptional.get().getLimitNum(),
+                        readEntityOptional.get().getOffset() * readEntityOptional.get().getLimitNum());
+                readDTOS.add(readDTO);
+            }
+        }
+        return readDTOS;
+    }
+
     @PostMapping("/island/books")
     public List<IslandBooksDTO> getBookInfoByislandId(@RequestBody IslandBooksDTO islandBooksDTO) {
         // 만약 userId가 -1이라면 비회원이므로 book info db를 island id로 검색한 결과만 리턴
@@ -46,7 +65,7 @@ public class IslandInfoController {
         for (Optional<BookInfoEntity> bookInfoEntityOptional : bookInfoEntityList) {
             bookInfoEntityOptional.ifPresent(bookInfoEntity -> {
                 IslandBooksDTO dto = new IslandBooksDTO(
-                        -1, // 비회원일 경우 userId는 -1로 설정
+                        islandBooksDTO.getUserId(), // 비회원일 경우 userId는 -1로 설정
                         bookInfoEntity.getId(),
                         islandBooksDTO.getIslandId(),
                         bookInfoEntity.getTitle(),
@@ -57,128 +76,11 @@ public class IslandInfoController {
                         bookInfoEntity.getImage(),
                         0.00f
                 );
+
                 islandBooksDTOList.add(dto);
+
             });
         }
         return islandBooksDTOList;
-//        if(islandBooksDTO.getUserId() < 0) {
-//
-//        }
-        
-        // 회원인 경우 read table에서 검색해야 함
-        // 회원인 경우 동화책 전체 반환하도록 하기!
-//        else {
-//            List<Optional<BookInfoEntity>> bookInfoEntityList = bookInfoService.findNameByIslandId(islandBooksDTO.getIslandId());
-//            log.info(String.valueOf(bookInfoEntityList.size()));
-//
-//            List<Optional<ReadEntity>> readEntityList = new ArrayList<>();
-//            // IslandBooksDTO로 변환해서 list로 리턴
-//
-//            for (Optional<BookInfoEntity> bookInfoEntityOptional : bookInfoEntityList) {
-//
-//                // (bookId, userId)로 read table 검색
-//                // 이때 book Id는 이미 island에 해당하는 bookId만을 고른 것임
-//                if(bookInfoEntityOptional.isPresent()) {
-//                    Integer userId = islandBooksDTO.getUserId();
-//                    Integer bookId = bookInfoEntityOptional.get().getId();
-//
-//                    if (bookId != null) {
-//
-//                        // read table에서 (userId, bookId) 검색
-//                        Optional<ReadEntity> readEntity = readService.findByUserIdAndBookId(userId, bookId);
-//
-//                        //readEntityList.add(readService.findByUserIdAndBookId(userId, bookId));
-//                        if(readEntity.isPresent()) { // optional은 is present 설정 필수
-//                            IslandBooksDTO dto = new IslandBooksDTO(
-//                                    islandBooksDTO.getUserId(), // 비회원일 경우 userId는 -1로 설정
-//                                    readEntity.get().getBookId(), // book id
-//                                    islandBooksDTO.getIslandId(), // island id
-//                                    bookInfoEntityOptional.get().getTitle(),
-//                                    bookInfoEntityOptional.get().getDescription(),
-//                                    bookInfoEntityOptional.get().getCategory(),
-//                                    bookInfoEntityOptional.get().getCountry(),
-//                                    bookInfoEntityOptional.get().getTotalPage(),
-//                                    bookInfoEntityOptional.get().getImage(),
-//                                    0.00f
-//                            );
-//
-//                            // progress 계산
-//                            DecimalFormat df = new DecimalFormat("#.##");
-//                            df.setRoundingMode(RoundingMode.HALF_UP);
-//
-//                            float progressCal = (readEntity.get().getOffset() + 1) * readEntity.get().getLimitNum();
-//                            float progressResult = progressCal / bookInfoEntityOptional.get().getTotalPage();
-//                            String formattedProgress = df.format(progressResult);
-//
-//                            float progressTemp = Float.parseFloat(formattedProgress);
-//                            dto.setProgress(progressTemp);
-//                            islandBooksDTOList.add(dto);
-//                        }
-//                        else { // read에 없으면 그냥 저장함
-//                            IslandBooksDTO dto = new IslandBooksDTO(
-//                                    islandBooksDTO.getUserId(), // 비회원일 경우 userId는 -1로 설정
-//                                    bookInfoEntityOptional.get().getId(), // book id
-//                                    islandBooksDTO.getIslandId(), // island id
-//                                    bookInfoEntityOptional.get().getTitle(),
-//                                    bookInfoEntityOptional.get().getDescription(),
-//                                    bookInfoEntityOptional.get().getCategory(),
-//                                    bookInfoEntityOptional.get().getCountry(),
-//                                    bookInfoEntityOptional.get().getTotalPage(),
-//                                    bookInfoEntityOptional.get().getImage(),
-//                                    0.00f
-//                            );
-//                            islandBooksDTOList.add(dto);
-//                        }
-//
-//                    }
-//                }
-//            }
-//            return islandBooksDTOList;
-//            log.info("readentitylist" + String.valueOf(readEntityList.size()));
-//
-//            // readEntityList에 있는 정보들을 islandBooksDTOList로 바꿔서 변환
-//            for(Optional<ReadEntity> readEntityOptional : readEntityList) {
-//                if(readEntityOptional.isPresent()) {
-//                    ReadEntity readEntity = readEntityOptional.get();
-//                    Integer bookId = readEntity.getBookId();
-//                    BookInfoDTO bookEntityOptional = bookInfoService.findById(bookId);
-//
-//                    log.info(bookEntityOptional.getTitle());
-//                    log.info("offset" + String.valueOf(readEntityOptional.get().getOffset()));
-//
-//                    IslandBooksDTO dto = new IslandBooksDTO(
-//                            islandBooksDTO.getUserId(), // 비회원일 경우 userId는 -1로 설정
-//                            readEntity.getId(),
-//                            islandBooksDTO.getIslandId(),
-//                            bookEntityOptional.getTitle(),
-//                            bookEntityOptional.getDescription(),
-//                            bookEntityOptional.getCategory(),
-//                            bookEntityOptional.getCountry(),
-//                            bookEntityOptional.getTotalPage(),
-//                            bookEntityOptional.getImage(),
-//                            0.00f
-//                    );
-//                    // progress 계산
-//                    DecimalFormat df = new DecimalFormat("#.##");
-//                    df.setRoundingMode(RoundingMode.HALF_UP);
-//
-//                    float progressCal = (readEntity.getOffset() + 1) * readEntity.getLimitNum();
-//                    float progressResult = progressCal / bookEntityOptional.getTotalPage();
-//                    String formattedProgress = df.format(progressResult);
-//
-//                    float progressTemp = Float.parseFloat(formattedProgress);
-//                    dto.setProgress(progressTemp);
-//                    islandBooksDTOList.add(dto);
-//
-////                    readEntityOptional.ifPresent(readEntity -> {
-////
-////                    });
-//                }
-//
-//
-//            }
-//            log.info(String.valueOf(islandBooksDTOList.size()));
-//            return islandBooksDTOList;
-
     }
 }

--- a/BE/src/main/java/com/FTIsland/BE/repository/ReadRepository.java
+++ b/BE/src/main/java/com/FTIsland/BE/repository/ReadRepository.java
@@ -2,6 +2,7 @@ package com.FTIsland.BE.repository;
 
 import com.FTIsland.BE.entity.ReadEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -9,6 +10,8 @@ import java.util.Optional;
 
 @Repository
 public interface ReadRepository extends JpaRepository<ReadEntity, Integer> {
+
+    @Query("SELECT r FROM ReadEntity r WHERE r.userId = :userId AND r.bookId = :bookId")
     Optional<ReadEntity> findByUserIdAndBookId(Integer userId, Integer bookId);
     List<ReadEntity> findByUserId(Integer userId);
     List<ReadEntity> findAllByUserIdOrderByUpdatedAtDesc(Integer userId);

--- a/BE/src/main/java/com/FTIsland/BE/repository/ReadRepository.java
+++ b/BE/src/main/java/com/FTIsland/BE/repository/ReadRepository.java
@@ -12,4 +12,6 @@ public interface ReadRepository extends JpaRepository<ReadEntity, Integer> {
     Optional<ReadEntity> findByUserIdAndBookId(Integer userId, Integer bookId);
     List<ReadEntity> findByUserId(Integer userId);
     List<ReadEntity> findAllByUserIdOrderByUpdatedAtDesc(Integer userId);
+
+    Optional<ReadEntity> findByBookId(int nowId);
 }

--- a/BE/src/main/java/com/FTIsland/BE/service/ReadService.java
+++ b/BE/src/main/java/com/FTIsland/BE/service/ReadService.java
@@ -1,5 +1,6 @@
 package com.FTIsland.BE.service;
 
+import com.FTIsland.BE.dto.IslandBooksDTO;
 import com.FTIsland.BE.dto.ReadDTO;
 import com.FTIsland.BE.entity.ReadEntity;
 import com.FTIsland.BE.repository.ReadRepository;
@@ -7,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -55,5 +57,23 @@ public class ReadService {
 
     public Optional<ReadEntity> findByBookId(int nowId) {
         return readRepository.findByBookId(nowId);
+    }
+
+    public List<ReadDTO> progress(IslandBooksDTO islandBooksDTO) {
+        List<ReadDTO> readDTOS = new ArrayList<>();
+
+        // islandid에서 힌트를 얻어서 바로 검색
+        int startNum = (islandBooksDTO.getIslandId() - 1) * 4 + 1;
+        for(int i = 0; i < 4; i++) {
+            int nowId = startNum + i;
+            Optional<ReadEntity> readEntityOptional = readRepository.findByUserIdAndBookId(islandBooksDTO.getUserId(), nowId);
+            if(readEntityOptional.isPresent()) {
+                ReadDTO readDTO = new ReadDTO(islandBooksDTO.getUserId(), readEntityOptional.get().getBookId(),
+                        readEntityOptional.get().getOffset(), readEntityOptional.get().getLimitNum(),
+                        readEntityOptional.get().getOffset() * readEntityOptional.get().getLimitNum());
+                readDTOS.add(readDTO);
+            }
+        }
+        return readDTOS;
     }
 }

--- a/BE/src/main/java/com/FTIsland/BE/service/ReadService.java
+++ b/BE/src/main/java/com/FTIsland/BE/service/ReadService.java
@@ -52,4 +52,8 @@ public class ReadService {
         Optional<ReadEntity> readEntity = readRepository.findByUserIdAndBookId(userId, bookId);
         return readEntity;
     }
+
+    public Optional<ReadEntity> findByBookId(int nowId) {
+        return readRepository.findByBookId(nowId);
+    }
 }


### PR DESCRIPTION
### Summary

- /island/info 회원, 비회원 모두 island의 book 정보만을 반환하도록 수정
- /book/progress API 첫번째 방식 구현 (약 3초)
- islandId-bookId 관계를 이용해 4개의 책 검색
- /book/progress 에서 progress 계산 위치를 read service로 변경

### Branch : fix/#76